### PR TITLE
74 fullysharedpolicy observationfunction improve other agents obs

### DIFF
--- a/src/eprllib/Env/EnvConfig.py
+++ b/src/eprllib/Env/EnvConfig.py
@@ -157,11 +157,6 @@ class EnvConfig:
         'zone_simulation_parameters': []
         
         * use_actuator_state: bool = False
-        * use_agent_indicator: bool = True
-        * use_thermal_zone_indicator: bool = False
-        * use_agent_type: bool = False
-        * use_building_properties: bool = False
-        * building_properties: Dict[str,Dict[str,float]] = NotImplemented
         * use_one_day_weather_prediction: bool = False
         * prediction_hours: int = 24
         * prediction_variables: Dict[str,bool] = {
@@ -266,11 +261,6 @@ class EnvConfig:
         self.infos_variables: Dict[str,List|Dict[str,List]] = NotImplemented # TODO: add actuators, weather_prediction, building_properties
         self.no_observable_variables: Dict[str,List|Dict[str,List]] = NotImplemented # TODO: add actuators, weather_prediction, building_properties
         self.use_actuator_state: bool = False
-        self.use_agent_indicator: bool = True
-        self.use_thermal_zone_indicator: bool = False
-        self.use_agent_type: bool = False
-        self.use_building_properties: bool = False
-        self.building_properties: Dict[str,Dict[str,float]] = NotImplemented
         self.use_one_day_weather_prediction: bool = False
         self.prediction_hours: int = 24
         self.prediction_variables: Dict[str,bool] = {
@@ -366,11 +356,6 @@ class EnvConfig:
         infos_variables: Dict[str,List[str]]|bool = NotImplemented,
         no_observable_variables: Dict[str,List[str]]|bool = False,
         use_actuator_state: Optional[bool] = False,
-        use_agent_indicator: Optional[bool] = True,
-        use_thermal_zone_indicator: Optional[bool] = False,
-        use_agent_type: Optional[bool] = False,
-        use_building_properties: Optional[bool] = False,
-        building_properties: Optional[Dict[str,Dict[str,float]]] = NotImplemented,
         use_one_day_weather_prediction: Optional[bool] = False,
         prediction_hours: int = 24,
         prediction_variables: Dict[str,bool]|bool = False,
@@ -380,15 +365,6 @@ class EnvConfig:
 
         Args:
             use_actuator_state (bool): define if the actuator state will be used as an observation for the agent.
-            use_agent_indicator (bool): define if agent indicator will be used as an observation for the agent. # DEPRECATED_VALUE
-            use_thermal_zone_indicator (bool): define if thermal zone indicator will be used as an observation for the agent.
-            This is recommended True for muilti-agent usage and False for single agent case.
-            use_agent_type (bool): define if the agent/actuator type will be used. This is recommended for different 
-            types of agents actuating in the same environment.
-            use_building_properties (bool): # define if the building properties will be used as an observation for 
-            the agent. This is recommended if different buildings/thermal zones will be used with the same policy.
-            building_properties (Dict[str,Dict[str,float]]): # The episode config define important aspects about the 
-            building to be simulated in the episode.
             use_one_day_weather_prediction (bool): We use the internal variables of EnergyPlus to provide with a 
             prediction of the weathertime ahead. The variables to predict are:
             
@@ -427,13 +403,6 @@ class EnvConfig:
         
         # TODO: Al least one variable must to be defined.
         self.use_actuator_state = use_actuator_state
-        self.use_agent_indicator = use_agent_indicator
-        self.use_thermal_zone_indicator = use_thermal_zone_indicator
-        self.use_agent_type = use_agent_type
-        self.use_building_properties = use_building_properties
-        self.building_properties = building_properties
-        if self.use_building_properties and self.building_properties == NotImplemented:
-            NotImplementedError("building_properties must be defined if use_building_properties is True.")
         self.use_one_day_weather_prediction = use_one_day_weather_prediction
         if prediction_hours <= 0 or prediction_hours > 24:
             self.prediction_hours = 24

--- a/src/eprllib/Env/MultiAgent/EnergyPlusRunner.py
+++ b/src/eprllib/Env/MultiAgent/EnergyPlusRunner.py
@@ -170,10 +170,6 @@ class EnergyPlusRunner:
             thermal_zone_states[thermal_zone].update(thermal_zone_states_p)
             thermal_zone_infos[thermal_zone].update(thermal_zone_infos_p)
             
-            thermal_zone_states_p, thermal_zone_infos_p = self.get_buiding_properties(state_argument, thermal_zone)
-            thermal_zone_states[thermal_zone].update(thermal_zone_states_p)
-            thermal_zone_infos[thermal_zone].update(thermal_zone_infos_p)
-            
         agent_states = {agent: {} for agent in self._agent_ids}
         agent_infos = {agent: {} for agent in self._agent_ids}
         for agent in self._agent_ids:
@@ -659,17 +655,6 @@ class EnergyPlusRunner:
                         weather_pred.update({f'tomorrow_weather_{key}_at_time_{prediction_hour_t}': prediction_variables_methods[f'tomorrow_weather_{key}_at_time']})
         
         return weather_pred, {}
-
-    def get_buiding_properties(
-        self,
-        thermal_zone: str = None
-    ) -> Tuple[Dict[str,Any],Dict[str,Any]]:
-        if not self.env_config['use_building_properties']:
-            return {}, {}
-        # Check that building_properties include all thermal_zones_id
-        assert set(self.env_config['building_properties'].keys()) == self._thermal_zone_ids, f"The building_properties must include all thermal_zones_id: {self._thermal_zone_ids}."
-        
-        return self.env_config['building_properties'][thermal_zone], {}
         
     def update_infos(
         self,

--- a/src/eprllib/ObservationFunctions/FullySharedParameters.py
+++ b/src/eprllib/ObservationFunctions/FullySharedParameters.py
@@ -47,6 +47,8 @@ class FullySharedParameters(ObservationFunction):
         super().__init__(config)
         self.number_of_agents_total: int = self.config['number_of_agents_total']
         self.number_of_thermal_zone_total: int = self.config['number_of_thermal_zone_total']
+        self.agent_obs_extra_var: Dict[str,Any] = self.config['agent_obs_extra_var']
+        self.other_agent_obs_extra_var: Dict[str,Any] = self.config['other_agent_obs_extra_var']
         self.observation_space_labels: Dict[str,List[str]] = None
     
     def get_agent_obs_dim(
@@ -84,23 +86,17 @@ class FullySharedParameters(ObservationFunction):
         # === Thermal zone state where the agent belongs ===
         # Thermal zone variables.
         obs_space_len += len(env_config['variables_thz'])
-        # Add static_variables and building properties.
+        
+        # Add static_variables.
         for thermal_zone in _thermal_zone_ids:
             lenght_vector_sv = []
-            lenght_vector_bp = []
             lenght_vector_sv.append(len([key for key in env_config['static_variables'][thermal_zone].keys()]))
-            if env_config['use_building_properties']:
-                lenght_vector_bp.append(len([key for key in env_config['building_properties'][thermal_zone].keys()]))
         # Check lenght vector elements are all the same, if don't a error happend.
         if len(set(lenght_vector_sv)) != 1:
             raise ValueError("The thermal zones have different number of static_variables.")
         # Add the lenght of the first thermal zone.
         obs_space_len += lenght_vector_sv[0]
-        if env_config['use_building_properties']:
-            # Check lenght vector elements are all the same, if don't a error happend.
-            if len(set(lenght_vector_bp)) != 1:
-                raise ValueError("The thermal zones have different number of building_properties.")
-            obs_space_len += lenght_vector_bp[0]
+        
         # zone_simulation_parameters: Count the keys in the dict that are True
         obs_space_len += len([key for key, value in env_config['zone_simulation_parameters'].items() if value])
     
@@ -124,7 +120,9 @@ class FullySharedParameters(ObservationFunction):
         if env_config['use_actuator_state']:
             obs_space_len += 1
             
-        # thermal_zone_indicator
+        # variables defined in agent_obs_extra_var
+        obs_space_len += len([key for key in self.config['agent_obs_extra_var'].keys()])
+        
         if env_config['use_thermal_zone_indicator']:
             obs_space_len += self.number_of_thermal_zone_total
             
@@ -134,8 +132,12 @@ class FullySharedParameters(ObservationFunction):
         
         # === Other agents reduce observations ===
         if self.number_of_agents_total > 1:
+            # multi-one hot-code vector
+            obs_space_len += self.number_of_agents_total
             for _ in range(self.number_of_agents_total):
-                obs_space_len += self.number_of_agents_total
+                
+                self.config['other_agent_obs_extra_var']
+                
                 # if apply, add the actuator state.
                 if env_config['use_actuator_state']:
                     obs_space_len += 1


### PR DESCRIPTION
**Changes**
The following variables were remove from the observation configuration:

* building_properties
* agent_type
* thermal_zone_indicator

In hte `FullySharedParameters` observation function, the variables `agent_obs_extra_var` and `other_agent_obs_extra_var` were added, and the other agent presence observation was modify as a multi-one-hot-encode vector, this means, a zero vector of the maximal longitude that the policy admidt with ones in the index that an agent indicator is active at that timestep.